### PR TITLE
Support concatenation like path.join

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ import { dirname, join } from 'desm'
 
 console.log(dirname(import.meta.url))
 console.log(join(import.meta.url, 'routes'))
+console.log(join(import.meta.url, '..', 'other'))
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ function urlDirname (url) {
   return dirname(fileURLToPath(url))
 }
 
-function urlJoin (url, str) {
-  return join(urlDirname(url), str)
+function urlJoin (url, ...str) {
+  return join(urlDirname(url), ...str)
 }
 
 export default urlDirname

--- a/test.js
+++ b/test.js
@@ -21,3 +21,10 @@ test('join stuff', async ({ is }) => {
 
   is(urlJoin(import.meta.url, 'routes'), join(__dirname, 'routes'))
 })
+
+test('join stuff (concat)', async ({ is }) => {
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = dirname(__filename)
+
+  is(urlJoin(import.meta.url, '..', 'routes'), join(__dirname, '..', 'routes'))
+})


### PR DESCRIPTION
As titled, now you can do:

```js
import { join } from 'desm'
join(import.meta.url, '..', 'routes')
```