### PR TITLE
feat: add convenience fileURLToPath() alias as filename()

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function urlJoin (url, ...str) {
 export default urlDirname
 
 export {
+  fileURLToPath as filename,
   urlJoin as join,
-  urlDirname as dirname
+  urlDirname as dirname,
 }

--- a/index.js
+++ b/index.js
@@ -14,5 +14,5 @@ export default urlDirname
 export {
   fileURLToPath as filename,
   urlJoin as join,
-  urlDirname as dirname,
+  urlDirname as dirname
 }


### PR DESCRIPTION
It is a common occurrence to have to import both `desm` and `fileURLToPath` since `fs` methods don't work with URLs.