### PR TITLE
feat: add filename export as syntactic sugar for url.fileURLToPath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version:
+          - 18
+          - 16
+          - 14
 
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -21,10 +21,18 @@ console.log(desm(import.meta.url))
 or
 
 ```js
-import { dirname, join } from 'desm'
+import { dirname, filename, join } from 'desm'
 
+// same as CommonJS __dirname
 console.log(dirname(import.meta.url))
+
+// same as CommonJS __filename
+console.log(filename(import.meta.url))
+
+// same as CommonJS path.join(__dirname, 'routes')
 console.log(join(import.meta.url, 'routes'))
+
+// same as CommonJS path.join(__dirname, '..', 'other')
 console.log(join(import.meta.url, '..', 'other'))
 ```
 

--- a/example.js
+++ b/example.js
@@ -1,0 +1,6 @@
+import desm from './index.js'
+import { filename, join } from './index.js'
+
+console.log('dirname of example.js:     ' + desm(import.meta.url))
+console.log('join dirname and "routes": ' + join(import.meta.url, 'routes'))
+console.log('filename of example.js:    ' + filename(import.meta.url))

--- a/example1.js
+++ b/example1.js
@@ -1,3 +1,0 @@
-import desm from './index.js'
-
-console.log(desm(import.meta.url))

--- a/example2.js
+++ b/example2.js
@@ -1,3 +1,0 @@
-import { join } from './index.js'
-
-console.log(join(import.meta.url, 'routes'))

--- a/example3.js
+++ b/example3.js
@@ -1,3 +1,0 @@
-import { filename } from './index.js'
-
-console.log(filename(import.meta.url))

--- a/example3.js
+++ b/example3.js
@@ -1,0 +1,3 @@
+import { filename } from './index.js'
+
+console.log(filename(import.meta.url))

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 export default urlDirname;
 declare function urlDirname(url: string): string;
 declare function urlJoin(url: string, ...str: string[]): string;
-export { urlJoin as join, urlDirname as dirname };
+declare function fileURLToPath(url: string | URL): string;
+export { fileURLToPath as filename, urlJoin as join, urlDirname as dirname };

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function urlJoin (url, ...str) {
 export default urlDirname
 
 export {
+  fileURLToPath as filename,
   urlJoin as join,
   urlDirname as dirname
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "homepage": "https://github.com/mcollina/desm#readme",
   "devDependencies": {
-    "tape": "^5.0.1"
+    "tape": "^5.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
   "main": "index.js",
   "typings": "index.d.ts",
   "type": "module",
-  "files": [
-    "index.js",
-    "index.d.ts"
-  ],
   "scripts": {
     "test": "node test.js"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "typings": "index.d.ts",
   "type": "module",
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "scripts": {
     "test": "node test.js"
   },

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 import {
   dirname as urlDirname,
+  filename,
   join as urlJoin
 } from './index.js'
 
@@ -13,6 +14,7 @@ test('carbon copy', async ({ is }) => {
 
   is(desm(import.meta.url), __dirname)
   is(urlDirname(import.meta.url), __dirname)
+  is(filename(import.meta.url), __filename)
 })
 
 test('join stuff', async ({ is }) => {


### PR DESCRIPTION
Meant to supersede #3.

Includes the following changes:

1. Add `filename` export as alias of `fileURLToPath` to index.js
2. Add unit test for `filename` export
3. ~~Add example3.js showing how to use `filename`~~ Combine examples into single module
4. Update README to include `filename` export and comments about equivalence to CommonJS globals
5. Update index.d.ts typings to include `filename` export
6. ~~Add `files` declaration to package.json to limit what gets included in published package~~
7. Update CI workflow to test on Node 16 and Node 18 (in addition to Node 14)
8. Upgrade version of `tape` dev dep explicitly to current latest version (5.5.3)

~~Number 6 changes the contents of the published package from this (desm version 1.2.0)~~:

```
npm notice === Tarball Contents === 
npm notice 432B  .github/workflows/ci.yml
npm notice 1.1kB LICENSE                 
npm notice 436B  README.md               
npm notice 66B   example1.js             
npm notice 80B   example2.js             
npm notice 193B  index.d.ts              
npm notice 298B  index.js                
npm notice 659B  package.json            
npm notice 849B  test.js                 
npm notice === Tarball Details === 
npm notice name:          desm                                    
npm notice version:       1.2.0                                   
npm notice filename:      desm-1.2.0.tgz                          
npm notice package size:  2.0 kB                                  
npm notice unpacked size: 4.1 kB                                  
npm notice shasum:        89ed05728cf6ec4ce64c2c87a5ab5555681210a4
npm notice integrity:     sha512-/sHgwtz8V4kzH[...]RgTrdfcRepDbw==
npm notice total files:   9
```

~~to this (via `npm pack .`)~~:

```
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE     
npm notice 656B  README.md   
npm notice 279B  index.d.ts  
npm notice 327B  index.js    
npm notice 710B  package.json
npm notice === Tarball Details === 
npm notice name:          desm                                    
npm notice version:       1.2.0                                   
npm notice filename:      desm-1.2.0.tgz                          
npm notice package size:  1.6 kB                                  
npm notice unpacked size: 3.0 kB                                  
npm notice shasum:        ce8fd9b2e3717255712b26b470821107a7d1937a
npm notice integrity:     sha512-CHdw8sN4Hc9Aq[...]Ep9ivJOJCIrZw==
npm notice total files:   5
```

~~Note that the next published version would exclude the following from the published package~~:
- .github/workflows/ci.yml
- example1.js
- example2.js
- test.js

If you would prefer I split up the "feat" changes from the "chore" changes in separate PRs, I can do that. Otherwise just trying to work efficiently.

Let me know if you have any concerns with my README changes.