### PR TITLE
Mention that import.meta.dirname is built-in now

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The missing one-liner utility to get the dirname from `import.meta.url`.
 
 Requires Node 12.17.0 or Node 14.0.0.
 
+Starting in [Node 20.11.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#20.11.0) and [Node 21.2.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V21.md#21.2.0) this is now built in: [`import.meta.dirname`](https://nodejs.org/api/esm.html#importmetadirname) / [`import.meta.filename`](https://nodejs.org/api/esm.html#importmetafilename)
+
 ## Install
 
 ```


### PR DESCRIPTION
Fixes #6